### PR TITLE
Enhance URL Shortener API with Expiration Logic, Deactivation Endpoint, and Fixes

### DIFF
--- a/UrlShortener.sln
+++ b/UrlShortener.sln
@@ -4,17 +4,19 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{827E0CD3-B72D-47B6-A68D-7590B98EB39B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "src/Domain/Domain.csproj", "{F275B02A-CEA8-4E8E-93C2-624172F61E43}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain", "src\Domain\Domain.csproj", "{F275B02A-CEA8-4E8E-93C2-624172F61E43}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application", "src/Application/Application.csproj", "{B2464221-5CA3-4114-9D65-06C74FFC14C1}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application", "src\Application\Application.csproj", "{B2464221-5CA3-4114-9D65-06C74FFC14C1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure", "src/Infrastructure/Infrastructure.csproj", "{C95BF538-7BBD-4280-B960-BE9046AD7910}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure", "src\Infrastructure\Infrastructure.csproj", "{C95BF538-7BBD-4280-B960-BE9046AD7910}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "API", "src/API/API.csproj", "{39FFC758-1A57-446C-8BCF-66896C463A88}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "API", "src\API\API.csproj", "{39FFC758-1A57-446C-8BCF-66896C463A88}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9943724D-379F-4307-A001-4C855E06EC45}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UrlShortener.Infrastructure.Tests", "tests/UrlShortener.Infrastructure.Tests/UrlShortener.Infrastructure.Tests.csproj", "{32E0CA51-D433-4902-B2E6-EF569E06015F}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UrlShortener.Infrastructure.Tests", "tests\UrlShortener.Infrastructure.Tests\UrlShortener.Infrastructure.Tests.csproj", "{32E0CA51-D433-4902-B2E6-EF569E06015F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UrlShortener.Api.Tests", "tests\UrlShortener.Api.Tests\UrlShortener.Api.Tests.csproj", "{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -86,6 +88,18 @@ Global
 		{32E0CA51-D433-4902-B2E6-EF569E06015F}.Release|x64.Build.0 = Release|Any CPU
 		{32E0CA51-D433-4902-B2E6-EF569E06015F}.Release|x86.ActiveCfg = Release|Any CPU
 		{32E0CA51-D433-4902-B2E6-EF569E06015F}.Release|x86.Build.0 = Release|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Debug|x64.Build.0 = Debug|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Debug|x86.Build.0 = Debug|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Release|x64.ActiveCfg = Release|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Release|x64.Build.0 = Release|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Release|x86.ActiveCfg = Release|Any CPU
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -96,5 +110,6 @@ Global
 		{C95BF538-7BBD-4280-B960-BE9046AD7910} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{39FFC758-1A57-446C-8BCF-66896C463A88} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{32E0CA51-D433-4902-B2E6-EF569E06015F} = {9943724D-379F-4307-A001-4C855E06EC45}
+		{D1A5D09D-51ED-4A22-8DE8-EC5E52FEBA02} = {9943724D-379F-4307-A001-4C855E06EC45}
 	EndGlobalSection
 EndGlobal

--- a/src/API/Controllers/UrlShortenerController.cs
+++ b/src/API/Controllers/UrlShortenerController.cs
@@ -46,7 +46,7 @@ namespace API.Controllers
                         Id = CreatedUrl.Id,
                         ShortCode = CreatedUrl.ShortCode,
                         OriginalUrl = CreatedUrl.OriginalUrl,
-                        ShortUrl = $"https://short.ly/{CreatedUrl.ShortCode}",
+                        ShortUrl = $"https://ShortUrl/{CreatedUrl.ShortCode}",
                         CreatedAt = CreatedUrl.CreatedAt,
                         UpdatedAt = CreatedUrl.UpdatedAt,
                         Title = CreatedUrl.Title,
@@ -217,10 +217,10 @@ namespace API.Controllers
             try
             {
                 var originalUrl = await _urlMappingService.RedirectToOriginalUrlAsync(shortCode);
-                
+
                 if (string.IsNullOrEmpty(originalUrl))
                     return NotFound("Short URL not found");
-                
+
                 return originalUrl;
             }
             catch (Exception ex)
@@ -229,5 +229,13 @@ namespace API.Controllers
                 return StatusCode(500, "Redirection error");
             }
         }
+
+        [HttpPost("DeactivateExpired")]
+        public async Task<IActionResult> DeactivateExpired()
+        {
+            await _urlMappingService.DeactivateExpiredUrlsAsync();
+            return NoContent();
+        }
+        
     }
 }

--- a/src/Domain/Interfaces/IUrlMappingRepository.cs
+++ b/src/Domain/Interfaces/IUrlMappingRepository.cs
@@ -10,6 +10,6 @@ namespace Domain.Interfaces
         Task<IEnumerable<UrlMapping>> GetActiveAsync();
         Task<bool> UrlExistsAsync(string shortCode);
         Task IncrementClickCountAsync(int id);
-
+        Task<IEnumerable<UrlMapping>> GetExpiredUrlsAsync();
     }
 }

--- a/src/Domain/Interfaces/IUrlMappingService.cs
+++ b/src/Domain/Interfaces/IUrlMappingService.cs
@@ -4,7 +4,7 @@ namespace Domain.Interfaces;
 
 public interface IUrlMappingService
 {
-    Task<UrlMapping> CreateUrlMappingAsync(UrlMapping urlMapping ,string? customShortCode = null);
+    Task<UrlMapping> CreateUrlMappingAsync(UrlMapping urlMapping, string? customShortCode = null);
     Task<UrlMapping?> GetByShortCodeAsync(string shortCode);
     Task<bool> UrlExistsAsync(string shortCode);
     Task<UrlMapping?> GetByIdAsync(int id);
@@ -13,5 +13,6 @@ public interface IUrlMappingService
     Task<IEnumerable<UrlMapping>> GetAllUrlsAsync();
     Task<string> RedirectToOriginalUrlAsync(string shortCode);
     Task DeleteUrlAsync(int id);
-    Task UpdateUrlAsync(UrlMapping urlMapping , string? customShortCode = null);
+    Task UpdateUrlAsync(UrlMapping urlMapping, string? customShortCode = null);
+    Task DeactivateExpiredUrlsAsync();
 }

--- a/tests/UrlShortener.Api.Tests/UrlShortener.Api.Tests.csproj
+++ b/tests/UrlShortener.Api.Tests/UrlShortener.Api.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FluentAssertions" Version="8.6.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\API\API.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/UrlShortener.Api.Tests/UrlShortenerControllerAndServiceTests.cs
+++ b/tests/UrlShortener.Api.Tests/UrlShortenerControllerAndServiceTests.cs
@@ -1,0 +1,313 @@
+﻿using System.Threading.Tasks;
+using API.Controllers;
+using API.DTOs.UrlMapping;
+using Application.Services;
+using Domain.Entities;
+using Domain.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace UrlShortener.Api.Tests
+{
+    public class UrlShortenerControllerAndServiceTests
+    {
+        private readonly UrlShortenerController _controller;
+        private readonly Mock<IUrlMappingService> _serviceMock;
+        private readonly Mock<ILogger<UrlShortenerController>> _loggerMock;
+
+        public UrlShortenerControllerAndServiceTests()
+        {
+            _serviceMock = new Mock<IUrlMappingService>();
+            _loggerMock = new Mock<ILogger<UrlShortenerController>>();
+            _controller = new UrlShortenerController(_loggerMock.Object, _serviceMock.Object);
+        }
+
+        [Fact]
+        public async Task CreateShortUrl_ShouldReturnCreatedAtActionResult_WhenRequestIsValid()
+        {
+            // Arrange
+            var request = new CreateUrlMappingRequest
+            {
+                OriginalUrl = "https://ElectronicAndGames.com",
+                CustomShortCode = "EAGA2025",
+                Title = "Electronic and Games",
+                Description = "Store for selling electronic devices and games",
+                ExpiresAt = DateTime.UtcNow.AddDays(30)
+            };
+
+            var createdUrl = new UrlMapping
+            {
+                Id = 1,
+                OriginalUrl = request.OriginalUrl,
+                ShortCode = request.CustomShortCode,
+                Title = request.Title,
+                Description = request.Description,
+                ExpiresAt = request.ExpiresAt,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            _serviceMock
+                .Setup(s => s.CreateUrlMappingAsync(It.IsAny<UrlMapping>(), request.CustomShortCode))
+                .ReturnsAsync(createdUrl);
+
+            // Act
+            var result = await _controller.CreateShortUrl(request);
+
+            // Assert
+            var createdResult = Assert.IsType<CreatedAtActionResult>(result.Result);
+            var response = Assert.IsType<CreateUrlMappingResponse>(createdResult.Value);
+
+            Assert.Equal(request.CustomShortCode, response.ShortCode);
+            Assert.Equal(1, response.Id);
+            Assert.Equal($"https://ShortUrl/{request.CustomShortCode}", response.ShortUrl);
+        }
+
+        [Fact]
+        public async Task DeleteUrlMapping_ShouldReturnNoContent_WhenUrlExists()
+        {
+            // Arrange
+            int urlId = 1;
+            var existingUrl = new UrlMapping { Id = urlId, ShortCode = "EAGA2025" };
+
+            _serviceMock.Setup(s => s.GetByIdAsync(urlId)).ReturnsAsync(existingUrl);
+            _serviceMock.Setup(s => s.DeleteUrlAsync(urlId)).Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _controller.DeleteUrlMapping(urlId);
+
+            // Assert
+            Assert.IsType<NoContentResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteUrlMapping_ShouldReturnNotFound_WhenUrlDoesNotExist()
+        {
+            // Arrange
+            int urlId = 1;
+            _serviceMock.Setup(s => s.GetByIdAsync(urlId)).ReturnsAsync((UrlMapping)null);
+
+            // Act
+            var result = await _controller.DeleteUrlMapping(urlId);
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result);
+            Assert.Equal(404, notFoundResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task UpdateUrl_ShouldReturnOk_WhenUpdateIsSuccessful()
+        {
+            // Arrange
+            var updateRequest = new UpdateUrlMappingRequest
+            {
+                Id = 1,
+                OriginalUrl = "https://UpdatedUrl.com",
+                Title = "Updated Title",
+                Description = "Updated description",
+                CustomShortCode = "EAGA2025",
+                ExpiresAt = DateTime.UtcNow.AddDays(30)
+            };
+
+            var existingUrl = new UrlMapping { Id = 1, ShortCode = "EAGA2025" };
+
+            _serviceMock.Setup(s => s.GetByIdAsync(updateRequest.Id)).ReturnsAsync(existingUrl);
+            _serviceMock.Setup(s => s.UpdateUrlAsync(It.IsAny<UrlMapping>(), updateRequest.CustomShortCode))
+                        .Returns(Task.CompletedTask);
+
+            // Act
+            var result = await _controller.UpdateUrl(updateRequest);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result); // for ActionResult<T>
+            var response = Assert.IsType<UrlMappingResponse>(okResult.Value);
+
+            Assert.Equal(updateRequest.CustomShortCode, response.ShortCode);
+        }
+
+        [Fact]
+        public async Task UpdateUrl_ShouldReturnNotFound_WhenUrlMappingDoesNotExist()
+        {
+            // Arrange
+            var updateRequest = new UpdateUrlMappingRequest
+            {
+                Id = 999, // non-existent ID
+                Title = "Attempted Update",
+                Description = "This update should fail",
+                CustomShortCode = "FAIL2025",
+                OriginalUrl = "http://nonexistent.com",
+                ExpiresAt = DateTime.UtcNow.AddDays(30)
+            };
+
+            // Mock the service to throw KeyNotFoundException when updating a non-existent URL mapping
+            _serviceMock
+                .Setup(s => s.UpdateUrlAsync(It.IsAny<UrlMapping>(), updateRequest.CustomShortCode))
+                .ThrowsAsync(new KeyNotFoundException("UrlMapping not found."));
+
+            // Act
+            var result = await _controller.UpdateUrl(updateRequest);
+
+            // Assert
+            var objectResult = Assert.IsType<NotFoundObjectResult>(result.Result); // Controller returns ObjectResult on exception
+            Assert.Equal(404, objectResult.StatusCode);
+            Assert.Equal($"URL with ID {updateRequest.Id} not found.", objectResult.Value);
+        }
+
+        [Fact]
+        public async Task GetAllUrls_ShouldReturnOk_WithAllUrls()
+        {
+            // Arrange
+            var urls = new List<UrlMapping>
+            {
+                new UrlMapping { Id = 1, ShortCode = "abc123", OriginalUrl = "http://example1.com" },
+                new UrlMapping { Id = 2, ShortCode = "def456", OriginalUrl = "http://example2.com" }
+            };
+            _serviceMock.Setup(s => s.GetAllUrlsAsync()).ReturnsAsync(urls);
+
+            // Act
+            var result = await _controller.GetAllUrls();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var response = Assert.IsAssignableFrom<IEnumerable<UrlMappingResponse>>(okResult.Value);
+            Assert.Equal(2, response.Count());
+        }
+
+        [Fact]
+        public async Task GetUrlById_ShouldReturnOk_WhenUrlExists()
+        {
+            // Arrange
+            var url = new UrlMapping { Id = 1, ShortCode = "abc123", OriginalUrl = "http://example.com" };
+            _serviceMock.Setup(s => s.GetByIdAsync(1)).ReturnsAsync(url);
+
+            // Act
+            var result = await _controller.GetUrlById(1);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var response = Assert.IsType<UrlMappingResponse>(okResult.Value);
+            Assert.Equal("abc123", response.ShortCode);
+        }
+
+        [Fact]
+        public async Task GetUrlById_ShouldReturnNotFound_WhenUrlDoesNotExist()
+        {
+            // Arrange
+            _serviceMock.Setup(s => s.GetByIdAsync(It.IsAny<int>())).ReturnsAsync((UrlMapping)null);
+
+            // Act
+            var result = await _controller.GetUrlById(999);
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+            Assert.Equal(404, notFoundResult.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetActiveUrls_ShouldReturnOk_WithActiveUrls()
+        {
+            // Arrange
+            var urls = new List<UrlMapping>
+            {
+                new UrlMapping { Id = 1, ShortCode = "active1", OriginalUrl = "http://active.com", IsActive = true },
+            };
+            _serviceMock.Setup(s => s.GetActiveUrlsAsync()).ReturnsAsync(urls);
+
+            // Act
+            var result = await _controller.GetActiveUrls();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var response = Assert.IsAssignableFrom<IEnumerable<UrlMappingResponse>>(okResult.Value);
+            Assert.Single(response);
+        }
+
+        [Fact]
+        public async Task GetMostClickedUrl_ShouldReturnOk_WithPopularUrls()
+        {
+            // Arrange
+            var urls = new List<UrlMapping>
+            {
+                new UrlMapping { Id = 1, ShortCode = "most1", OriginalUrl = "http://popular.com", ClickCount = 10 },
+                new UrlMapping { Id = 2, ShortCode = "most2", OriginalUrl = "http://popular2.com", ClickCount = 8 }
+            };
+            _serviceMock.Setup(s => s.GetMostClickedUrlsAsync(2)).ReturnsAsync(urls);
+
+            // Act
+            var result = await _controller.GetMostClickedUrl(2);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var response = Assert.IsAssignableFrom<IEnumerable<UrlMappingResponse>>(okResult.Value);
+            Assert.Equal(2, response.Count());
+        }
+
+        [Fact]
+        public async Task RedirectToOriginalUrl_ShouldReturnUrl_WhenShortCodeExists()
+        {
+            // Arrange
+            _serviceMock.Setup(s => s.RedirectToOriginalUrlAsync("abc123")).ReturnsAsync("http://original.com");
+
+            // Act
+            var result = await _controller.RedirectToOriginalUrl("abc123");
+
+            // Assert
+            var okResult = Assert.IsType<ActionResult<string>>(result);
+            Assert.Equal("http://original.com", okResult.Value);
+        }
+
+        [Fact]
+        public async Task RedirectToOriginalUrl_ShouldReturnNotFound_WhenShortCodeDoesNotExist()
+        {
+            // Arrange
+            _serviceMock.Setup(s => s.RedirectToOriginalUrlAsync("nonexistent")).ReturnsAsync(string.Empty);
+
+            // Act
+            var result = await _controller.RedirectToOriginalUrl("nonexistent");
+
+            // Assert
+            var notFoundResult = Assert.IsType<NotFoundObjectResult>(result.Result);
+            Assert.Equal("Short URL not found", notFoundResult.Value);
+        }
+
+
+        [Fact]
+        public async Task DeactivateExpiredUrlsAsync_ShouldSetIsActiveFalse_ForExpiredUrls()
+        {
+            var mockRepo = new Mock<IUrlMappingRepository>();
+            var mockUnitOfWork = new Mock<IUnitOfWork>();
+            var mockLogger = new Mock<ILogger<UrlMappingService>>();
+            var mockShortUrlService = new Mock<IShortUrlGeneratorService>();
+            var mockRedis = new Mock<IConnectionMultiplexer>();
+            mockRedis.Setup(x => x.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(Mock.Of<IDatabase>());
+
+            var service = new UrlMappingService(
+                mockRepo.Object,
+                mockUnitOfWork.Object,
+                mockLogger.Object,
+                mockShortUrlService.Object,
+                mockRedis.Object
+            );
+
+            //Arrange
+            var expiredUrls = new List<UrlMapping>
+            {
+                new UrlMapping { Id = 1, IsActive = true, ExpiresAt = DateTime.UtcNow.AddDays(-1) },
+                new UrlMapping { Id = 2, IsActive = true, ExpiresAt = DateTime.UtcNow.AddHours(-2) }
+            };
+            mockRepo.Setup(r => r.GetExpiredUrlsAsync()).ReturnsAsync(expiredUrls);
+            mockUnitOfWork.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(1);
+            //Act
+            await service.DeactivateExpiredUrlsAsync();
+            // Assert
+            Assert.All(expiredUrls, u => Assert.False(u.IsActive));
+            mockRepo.Verify(r => r.UpdateAsync(It.IsAny<UrlMapping>()), Times.Exactly(expiredUrls.Count));
+            mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+
+
+        }
+    }
+}

--- a/tests/UrlShortener.Infrastructure.Tests/UrlMappingRepositoryTest.cs
+++ b/tests/UrlShortener.Infrastructure.Tests/UrlMappingRepositoryTest.cs
@@ -1,4 +1,4 @@
-﻿
+﻿﻿
 using System.Threading.Tasks;
 using Domain.Entities;
 using Moq;


### PR DESCRIPTION
_This PR introduces new functionality, improvements, and fixes to the URL Shortener API:_

**New Features**

- Expiration logic:   Automatically deactivate expired URLs (IsActive = false when ExpiresAt < DateTime.UtcNow).
- DeactivateExpired endpoint: New API endpoint to trigger deactivation of expired URLs.
- Unit tests: Added tests for both service and controller to ensure correct expired URL handling.

**Fixes**

- Fixed endpoint errors related to redirection and update operations.
- Corrected click count tracking to ensure increments work properly for cached URLs.

 **Modifications**
 
- Added a new URL mapping controller with CRUD operations.
- Updated URL shortening services for better error handling and validation.
- Introduced UpdateUrlMappingRequest DTO for update operations.
- Strengthened transaction safety with Unit of Work pattern.