### PR TITLE
refactor: error handling

### DIFF
--- a/src/API/Controllers/UrlShortenerController.cs
+++ b/src/API/Controllers/UrlShortenerController.cs
@@ -3,6 +3,7 @@ using API.DTOs.UrlMapping;
 using Microsoft.AspNetCore.Mvc;
 using Domain.Entities;
 using Domain.Interfaces;
+using Domain.Result;
 
 namespace API.Controllers
 {
@@ -26,43 +27,42 @@ namespace API.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         public async Task<ActionResult<CreateUrlMappingResponse>> CreateShortUrl([FromBody] CreateUrlMappingRequest request)
         {
-            try
+            
+            var urlMapping = new UrlMapping
             {
-                var urlMapping = new UrlMapping
-                {
-                    OriginalUrl = request.OriginalUrl,
-                    ExpiresAt = request.ExpiresAt,
-                    Title = request.Title,
-                    Description = request.Description,
-                };
-                var CreatedUrl = await _urlMappingService.CreateUrlMappingAsync(urlMapping, request.CustomShortCode);
+                OriginalUrl = request.OriginalUrl,
+                ExpiresAt = request.ExpiresAt,
+                Title = request.Title,
+                Description = request.Description,
+            };
+            var CreatedUrl = await _urlMappingService.CreateUrlMappingAsync(urlMapping, request.CustomShortCode);
+            if (CreatedUrl is Failure<UrlMapping> failure) {
+                return StatusCode((int)failure.error.code, failure.error.message);
+            }
+            if (CreatedUrl is Success<UrlMapping> url) {
                 return CreatedAtAction
                 (
                     nameof(GetUrlById),
-                    new { id = CreatedUrl.Id },
+                    new { id = url.res.Id },
                     new CreateUrlMappingResponse
                     {
-                        Id = CreatedUrl.Id,
-                        ShortCode = CreatedUrl.ShortCode,
-                        OriginalUrl = CreatedUrl.OriginalUrl,
-                        ShortUrl = $"https://ShortUrl/{CreatedUrl.ShortCode}",
-                        CreatedAt = CreatedUrl.CreatedAt,
-                        UpdatedAt = CreatedUrl.UpdatedAt,
-                        Title = CreatedUrl.Title,
-                        Description = CreatedUrl.Description,
-                        ExpiresAt = CreatedUrl.ExpiresAt,
-                        IsActive = CreatedUrl.IsActive,
-                        ClickCount = CreatedUrl.ClickCount
+                        Id = url.res.Id,
+                        ShortCode = url.res.ShortCode,
+                        OriginalUrl = url.res.OriginalUrl,
+                        ShortUrl = $"https://ShortUrl/{url.res.ShortCode}",
+                        CreatedAt = url.res.CreatedAt,
+                        UpdatedAt = url.res.UpdatedAt,
+                        Title = url.res.Title,
+                        Description = url.res.Description,
+                        ExpiresAt = url.res.ExpiresAt,
+                        IsActive = url.res.IsActive,
+                        ClickCount = url.res.ClickCount
                     }
                 );
             }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error creating short URL");
-                return StatusCode(500, "Internal server error");
-            }
-
+            return StatusCode(500, "Internal server error");
         }
+
         [HttpDelete]
         public async Task<IActionResult> DeleteUrlMapping(int Id)
         {
@@ -84,18 +84,28 @@ namespace API.Controllers
         public async Task<ActionResult<UrlMappingResponse>> UpdateUrl([FromBody] UpdateUrlMappingRequest request)
         {
             var existingUrl = await _urlMappingService.GetByIdAsync(request.Id);
-            if (existingUrl == null)
-            {
+            if (existingUrl is Failure<UrlMapping> existingUrlFailure) {
+                return StatusCode((int)existingUrlFailure.error.code, existingUrlFailure.error.message);
+            }
+            var url = (existingUrl as Success<UrlMapping>)?.res;
+            if (url == null) {
                 return NotFound($"URL with ID {request.Id} not found.");
             }
-            existingUrl.Title = request.Title ?? existingUrl.Title;
-            existingUrl.Description = request.Description ?? existingUrl.Description;
-            existingUrl.OriginalUrl = request.OriginalUrl ?? existingUrl.OriginalUrl;
-            existingUrl.ExpiresAt = request.ExpiresAt;
-            existingUrl.IsActive = request.IsActive;
-            existingUrl.UpdatedAt = DateTime.UtcNow;
+            url.Title = request.Title ?? url.Title;
+            url.Description = request.Description ?? url.Description;
+            url.OriginalUrl = request.OriginalUrl ?? url.OriginalUrl;
+            url.ExpiresAt = request.ExpiresAt;
+            url.IsActive = request.IsActive;
+            url.UpdatedAt = DateTime.UtcNow;
 
-            var updatedUrl = await _urlMappingService.UpdateUrlAsync(existingUrl, request.CustomShortCode);
+            var updateUrlResult = await _urlMappingService.UpdateUrlAsync(url, request.CustomShortCode);
+            if (updateUrlResult is Failure<UrlMapping> updateUrlFailure) {
+                return StatusCode((int)updateUrlFailure.error.code, updateUrlFailure.error.message);
+            }
+            var updatedUrl = (updateUrlResult as Success<UrlMapping>)?.res;
+            if (updatedUrl == null) {
+                return StatusCode(500, "Internal server error");
+            }
             return Ok(new UrlMappingResponse
             {
                 Id = updatedUrl.Id,
@@ -113,10 +123,13 @@ namespace API.Controllers
         [HttpGet("GetAll")]
         public async Task<ActionResult<IEnumerable<UrlMappingResponse>>> GetAllUrls()
         {
-            var urlMappings = await _urlMappingService.GetAllUrlsAsync();
+            var urlMappingsResult = await _urlMappingService.GetAllUrlsAsync();
+            if (urlMappingsResult is Failure<IEnumerable<UrlMapping>> urlMappingsFailure) {
+                return StatusCode((int)urlMappingsFailure.error.code, urlMappingsFailure.error.message);
+            }
+            var urlMappings = (urlMappingsResult as Success<IEnumerable<UrlMapping>>)!.res;
             return Ok(urlMappings.Select(um => new UrlMappingResponse
             {
-                Id = um.Id,
                 OriginalUrl = um.OriginalUrl,
                 ShortCode = um.ShortCode,
                 ShortUrl = $"https//:localhost/{um.ShortCode}",
@@ -131,22 +144,25 @@ namespace API.Controllers
         [HttpGet("GetById/{id}")]
         public async Task<ActionResult<UrlMappingResponse>> GetUrlById(int id)
         {
-            var existingUrl = await _urlMappingService.GetByIdAsync(id);
-            if (existingUrl == null)
-            {
+            var existingUrlResult = await _urlMappingService.GetByIdAsync(id);
+            if (existingUrlResult is Failure<UrlMapping> existingUrlFailure) {
+                return StatusCode((int)existingUrlFailure.error.code, existingUrlFailure.error.message);
+            }
+            var url = (existingUrlResult as Success<UrlMapping>)?.res;
+            if (url == null) {
                 return NotFound($"URL with ID {id} not found.");
             }
             return Ok(new UrlMappingResponse
             {
-                Id = existingUrl.Id,
-                ShortCode = existingUrl.ShortCode,
-                OriginalUrl = existingUrl.OriginalUrl,
-                ShortUrl = $"https://{existingUrl.ShortCode}",
-                Title = existingUrl.Title,
-                Description = existingUrl.Description,
-                ExpiresAt = existingUrl.ExpiresAt,
-                IsActive = existingUrl.IsActive,
-                ClickCount = existingUrl.ClickCount
+                Id = url.Id,
+                ShortCode = url.ShortCode,
+                OriginalUrl = url.OriginalUrl,
+                ShortUrl = $"https://{url.ShortCode}",
+                Title = url.Title,
+                Description = url.Description,
+                ExpiresAt = url.ExpiresAt,
+                IsActive = url.IsActive,
+                ClickCount = url.ClickCount
             });
         }
         [HttpGet("MostClicked/{limit}")]
@@ -156,39 +172,35 @@ namespace API.Controllers
             {
                 return BadRequest("Limit must be between 1 and 100");
             }
-            try
-            {
-                var popularUrls = await _urlMappingService.GetMostClickedUrlsAsync(limit);
-                var response = popularUrls.Select(um => new UrlMappingResponse
-                {
-                    Id = um.Id,
-                    OriginalUrl = um.OriginalUrl,
-                    ShortUrl = $"https://{um.ShortCode}",
-                    ShortCode = um.ShortCode,
-                    Title = um.Title,
-                    Description = um.Description,
-                    ExpiresAt = um.ExpiresAt,
-                    ClickCount = um.ClickCount,
-                    IsActive = um.IsActive,
-                    CreatedAt = um.CreatedAt
-                });
-
-                return Ok(response);
+            var popularUrlsResult = await _urlMappingService.GetMostClickedUrlsAsync(limit);
+            if (popularUrlsResult is Failure<IEnumerable<UrlMapping>> popularUrlsFailure) {
+                return StatusCode((int)popularUrlsFailure.error.code, popularUrlsFailure.error.message);
             }
-            catch (Exception ex)
+            var popularUrls = (popularUrlsResult as Success<IEnumerable<UrlMapping>>)!.res;
+            return Ok(popularUrls.Select(um => new UrlMappingResponse
             {
-                _logger.LogError(ex, "Error fetching most clicked URLs");
-                return StatusCode(500, "Internal server error");
-            }
+                Id = um.Id,
+                OriginalUrl = um.OriginalUrl,
+                ShortUrl = $"https://{um.ShortCode}",
+                ShortCode = um.ShortCode,
+                Title = um.Title,
+                Description = um.Description,
+                ExpiresAt = um.ExpiresAt,
+                ClickCount = um.ClickCount,
+                IsActive = um.IsActive,
+                CreatedAt = um.CreatedAt
+            }));
         }
 
         [HttpGet("/allActiveUrls")]
         public async Task<ActionResult<IEnumerable<UrlMappingResponse>>> GetActiveUrls()
         {
-            try
-            {
-                var ActiveUrls = await _urlMappingService.GetActiveUrlsAsync();
-                var response = ActiveUrls.Select(um => new UrlMappingResponse
+                var activeUrlsResult = await _urlMappingService.GetActiveUrlsAsync();
+                if (activeUrlsResult is Failure<IEnumerable<UrlMapping>> activeUrlsFailure) {
+                    return StatusCode((int)activeUrlsFailure.error.code, activeUrlsFailure.error.message);
+                }
+                var activeUrls = (activeUrlsResult as Success<IEnumerable<UrlMapping>>)!.res;
+                return Ok(activeUrls.Select(um => new UrlMappingResponse
                 {
                     Id = um.Id,
                     OriginalUrl = um.OriginalUrl,
@@ -200,39 +212,28 @@ namespace API.Controllers
                     ClickCount = um.ClickCount,
                     IsActive = um.IsActive,
                     CreatedAt = um.CreatedAt
-                });
-
-                return Ok(response);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Error fetching most Active URLs");
-                return StatusCode(500, "Internal server error");
-            }
+                }));
         }
         [HttpGet("RedirectRoOriginalUrl/{shortCode}")]
         public async Task<ActionResult<String>> RedirectToOriginalUrl(string shortCode)
         {
-            try
-            {
-                var originalUrl = await _urlMappingService.RedirectToOriginalUrlAsync(shortCode);
-
+                var originalUrlResult = await _urlMappingService.RedirectToOriginalUrlAsync(shortCode);
+                if (originalUrlResult is Failure<string> originalUrlFailure) {
+                    return StatusCode((int)originalUrlFailure.error.code, originalUrlFailure.error.message);
+                }
+                var originalUrl = (originalUrlResult as Success<string>)?.res;
                 if (string.IsNullOrEmpty(originalUrl))
                     return NotFound("Short URL not found");
-
                 return originalUrl;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Redirection failed for {ShortCode}", shortCode);
-                return StatusCode(500, "Redirection error");
-            }
         }
 
         [HttpPost("DeactivateExpired")]
         public async Task<IActionResult> DeactivateExpired()
         {
-            await _urlMappingService.DeactivateExpiredUrlsAsync();
+            var deactivateExpiredResult = await _urlMappingService.DeactivateExpiredUrlsAsync();
+            if (deactivateExpiredResult != null) {
+                return StatusCode((int)deactivateExpiredResult.code, deactivateExpiredResult.message);
+            }
             return NoContent();
         }
         

--- a/src/Domain/Interfaces/IRepository.cs
+++ b/src/Domain/Interfaces/IRepository.cs
@@ -1,12 +1,13 @@
 using Domain.Entities;
+using Domain.Result;
 
 namespace Domain.Interfaces;
 
 public interface IRepository<T> where T : BaseEntity
 {
-    Task<T?> GetByIdAsync(int id);
-    Task<IEnumerable<T>> GetAllAsync();
-    Task<T> AddAsync(T entity);
+    Task<Result<T?>> GetByIdAsync(int id);
+    Task<Result<IEnumerable<T>>> GetAllAsync();
+    Task<Result<T>> AddAsync(T entity);
     Task UpdateAsync(T entity);
-    Task DeleteAsync(int id);
+    Task<Error?> DeleteAsync(int id);
 }

--- a/src/Domain/Interfaces/IShortUrlGeneratorService.cs
+++ b/src/Domain/Interfaces/IShortUrlGeneratorService.cs
@@ -1,4 +1,4 @@
-
+using Domain.Result;
 
 namespace Domain.Interfaces
 {

--- a/src/Domain/Interfaces/IUrlMappingRepository.cs
+++ b/src/Domain/Interfaces/IUrlMappingRepository.cs
@@ -1,15 +1,16 @@
 
 using Domain.Entities;
+using Domain.Result;
 
 namespace Domain.Interfaces
 {
     public interface IUrlMappingRepository : IRepository<UrlMapping>
     {
-        Task<IEnumerable<UrlMapping>> GetMostClickedAsync(int limit);
-        Task<UrlMapping?> GetByShortCodeAsync(string shortCode);
-        Task<IEnumerable<UrlMapping>> GetActiveAsync();
-        Task<bool> UrlExistsAsync(string shortCode);
-        Task IncrementClickCountAsync(int id);
-        Task<IEnumerable<UrlMapping>> GetExpiredUrlsAsync();
+        Task<Result<IEnumerable<UrlMapping>>> GetMostClickedAsync(int limit);
+        Task<Result<UrlMapping?>> GetByShortCodeAsync(string shortCode);
+        Task<Result<IEnumerable<UrlMapping>>> GetActiveAsync();
+        Task<Result<bool>> UrlExistsAsync(string shortCode);
+        Task<Error?> IncrementClickCountAsync(int id);
+        Task<Result<IEnumerable<UrlMapping>>> GetExpiredUrlsAsync();
     }
 }

--- a/src/Domain/Interfaces/IUrlMappingService.cs
+++ b/src/Domain/Interfaces/IUrlMappingService.cs
@@ -1,18 +1,19 @@
 using Domain.Entities;
+using Domain.Result;
 
 namespace Domain.Interfaces;
 
 public interface IUrlMappingService
 {
-    Task<UrlMapping> CreateUrlMappingAsync(UrlMapping urlMapping, string? customShortCode = null);
-    Task<UrlMapping?> GetByShortCodeAsync(string shortCode);
-    Task<bool> UrlExistsAsync(string shortCode);
-    Task<UrlMapping?> GetByIdAsync(int id);
-    Task<IEnumerable<UrlMapping>> GetMostClickedUrlsAsync(int limit);
-    Task<IEnumerable<UrlMapping>> GetActiveUrlsAsync();
-    Task<IEnumerable<UrlMapping>> GetAllUrlsAsync();
-    Task<string> RedirectToOriginalUrlAsync(string shortCode);
-    Task DeleteUrlAsync(int id);
-    Task<UrlMapping> UpdateUrlAsync(UrlMapping urlMapping, string? customShortCode = null);
-    Task DeactivateExpiredUrlsAsync();
+    Task<Result<UrlMapping>> CreateUrlMappingAsync(UrlMapping urlMapping, string? customShortCode = null);
+    Task<Result<UrlMapping?>> GetByShortCodeAsync(string shortCode);
+    Task<Result<bool>> UrlExistsAsync(string shortCode);
+    Task<Result<UrlMapping?>> GetByIdAsync(int id);
+    Task<Result<IEnumerable<UrlMapping>>> GetMostClickedUrlsAsync(int limit);
+    Task<Result<IEnumerable<UrlMapping>>> GetActiveUrlsAsync();
+    Task<Result<IEnumerable<UrlMapping>>> GetAllUrlsAsync();
+    Task<Result<string>> RedirectToOriginalUrlAsync(string shortCode);
+    Task<Error?> DeleteUrlAsync(int id);
+    Task<Result<UrlMapping>> UpdateUrlAsync(UrlMapping urlMapping, string? customShortCode = null);
+    Task<Error?> DeactivateExpiredUrlsAsync();
 }

--- a/src/Domain/Result/Error.cs
+++ b/src/Domain/Result/Error.cs
@@ -1,0 +1,18 @@
+namespace Domain.Result;
+
+public enum ErrorCode {
+    NOT_FOUND=404,
+    BAD_REQUEST=400,
+    UNAUTHORIZED=401,
+    FORBIDDEN=403,
+    INTERNAL_SERVER_ERROR=500,
+}
+
+public class Error {
+    public string message;
+    public ErrorCode code;
+    public Error(string message, ErrorCode code) {
+        this.message = message;
+        this.code = code;
+    }
+}

--- a/src/Domain/Result/Result.cs
+++ b/src/Domain/Result/Result.cs
@@ -1,0 +1,21 @@
+namespace Domain.Result;
+
+public interface Result<T> {
+    bool is_success();
+}
+
+public class Success<T> : Result<T> {
+    public T res;
+    public Success(T res) {
+        this.res = res;
+    }
+    public bool is_success() {return true;}
+}
+
+public class Failure<T> : Result<T> {
+    public Error error;
+    public Failure(Error error) {
+        this.error = error;
+    }
+    public bool is_success() {return false;}
+}

--- a/src/Infrastructure/Repositories/UrlMappingRepository.cs
+++ b/src/Infrastructure/Repositories/UrlMappingRepository.cs
@@ -4,6 +4,7 @@ using Domain.Interfaces;
 using Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Domain.Result;
 
 namespace Infrastructure.Repositories
 {
@@ -26,25 +27,35 @@ namespace Infrastructure.Repositories
         }
 
         // Implement the methods defined in the IUrlMappingRepository interface
-        public async Task<UrlMapping> AddAsync(UrlMapping entity)
+        public async Task<Result<UrlMapping>> AddAsync(UrlMapping entity)
         {
-
-            // Add the UrlMapping entity to the DbSet and return the added entity
-            var AddedUrl = await _dbSet.AddAsync(entity);
-            return AddedUrl.Entity;
+            try {
+                // Add the UrlMapping entity to the DbSet and return the added entity
+                var AddedUrl = await _dbSet.AddAsync(entity);
+                return new Success<UrlMapping>(AddedUrl.Entity);
+            } catch (Exception ex) {
+                _logger.LogError(ex, "Error adding UrlMapping");
+                return new Failure<UrlMapping>(new Error("Error adding UrlMapping", ErrorCode.INTERNAL_SERVER_ERROR));
+            }
         }
 
-        public async Task DeleteAsync(int Id)
+        public async Task<Error?> DeleteAsync(int Id)
         {
-            var urlMapping = await _dbSet.FirstOrDefaultAsync(u => u.Id == Id);
-            if (urlMapping == null)
-            {
-                _logger.LogWarning($"No UrlMapping found for Id: {Id}");
-                return;
+            try {
+
+                var urlMapping = await _dbSet.FirstOrDefaultAsync(u => u.Id == Id);
+                if (urlMapping == null)
+                {
+                    _logger.LogWarning($"No UrlMapping found for Id: {Id}");
+                    return new Error($"No UrlMapping found for Id: {Id}", ErrorCode.NOT_FOUND);
+                }
+                //if it not null, remove it from the DbSet
+                _dbSet.Remove(urlMapping);
+                return null;
+            } catch (Exception ex) {
+                _logger.LogError(ex, "Error deleting UrlMapping");
+                return new Error(ex.Message, ErrorCode.INTERNAL_SERVER_ERROR);
             }
-            //if it not null, remove it from the DbSet
-            _dbSet.Remove(urlMapping);
-            return;
         }
 
         public Task UpdateAsync(UrlMapping urlMapping)
@@ -65,72 +76,115 @@ namespace Infrastructure.Repositories
             _context.Entry(urlMapping).State = EntityState.Modified;
             return Task.CompletedTask;
         }
-        public async Task<IEnumerable<UrlMapping>> GetActiveAsync()
+        public async Task<Result<IEnumerable<UrlMapping>>> GetActiveAsync()
         {
-            // Fetch all active URL and return the activ as a list
-            var activeurls = await _dbSet
-            .Where(u => u.IsActive == true)
-            .ToListAsync();
+            try {
+                // Fetch all active URL and return the activ as a list
+                var activeurls = await _dbSet
+                .Where(u => u.IsActive == true)
+                .ToListAsync();
 
-            return activeurls;
+                return new Success<IEnumerable<UrlMapping>>(activeurls);
+            } catch (Exception ex) {
+                _logger.LogError(ex, "Error fetching active URLs");
+                return new Failure<IEnumerable<UrlMapping>>(new Error(ex.Message, ErrorCode.INTERNAL_SERVER_ERROR));
+            }
         }
 
-        public async Task<IEnumerable<UrlMapping>> GetAllAsync()
+        public async Task<Result<IEnumerable<UrlMapping>>> GetAllAsync()
         {
-            return await _dbSet.ToListAsync();
+            try {
+                var allurls = await _dbSet.ToListAsync();
+                return new Success<IEnumerable<UrlMapping>>(allurls);
+            } catch (Exception ex) {
+                _logger.LogError(ex, "Error fetching all URLs");
+                return new Failure<IEnumerable<UrlMapping>>(new Error(ex.Message, ErrorCode.INTERNAL_SERVER_ERROR));
+            }
         }
 
-        public async Task<UrlMapping?> GetByIdAsync(int Id)
+        public async Task<Result<UrlMapping?>> GetByIdAsync(int Id)
         {
 
-            return await _dbSet.Where(u => u.Id == Id)
+            try {
+                var url = await _dbSet.Where(u => u.Id == Id)
                 .FirstOrDefaultAsync();
+                return new Success<UrlMapping?>(url);
+            } catch (Exception ex) {
+                _logger.LogError(ex, "Error fetching URL by Id");
+                return new Failure<UrlMapping?>(new Error(ex.Message, ErrorCode.INTERNAL_SERVER_ERROR));
+            }
         }
 
 
-        public async Task<IEnumerable<UrlMapping>> GetMostClickedAsync(int limit)
+        public async Task<Result<IEnumerable<UrlMapping>>> GetMostClickedAsync(int limit)
         {
             if (limit <= 0)
             {
                 _logger.LogError("Invalid limit value: {Limit}. It must be greater than zero.", limit);
-                throw new ArgumentOutOfRangeException(nameof(limit), "Limit must be greater than zero.");
+                return new Failure<IEnumerable<UrlMapping>>(new Error("Limit must be greater than zero.", ErrorCode.BAD_REQUEST));
             }
             // Fetch the most clicked URLs, ordered by ClickCount in descending order
             // and limited to the specified number of results
-            return await _dbSet
+            try {
+                var mostClickedUrls = await _dbSet
                 .Where(u => u.ClickCount > 0)
                 .OrderByDescending(u => u.ClickCount)
                 .Take(limit)
                 .AsNoTracking() // Better performance for read-only
                 .ToListAsync();
+                return new Success<IEnumerable<UrlMapping>>(mostClickedUrls);
+            } catch (Exception ex) {
+                _logger.LogError(ex, "Error fetching most clicked URLs");
+                return new Failure<IEnumerable<UrlMapping>>(new Error(ex.Message, ErrorCode.INTERNAL_SERVER_ERROR));
+            }
         }
-        public async Task<UrlMapping?> GetByShortCodeAsync(string shortCode)
+        public async Task<Result<UrlMapping?>> GetByShortCodeAsync(string shortCode)
         {
-
-
-            return await _dbSet
-                .Where(u => u.ShortCode == shortCode)
+            try {
+                var url = await _dbSet.Where(u => u.ShortCode == shortCode)
                 .FirstOrDefaultAsync();
+                return new Success<UrlMapping?>(url);
+            } catch (Exception ex) {
+                _logger.LogError(ex, "Error fetching URL by short code");
+                return new Failure<UrlMapping?>(new Error(ex.Message, ErrorCode.INTERNAL_SERVER_ERROR));
+            }
         }
-        public async Task<bool> UrlExistsAsync(string shortCode)
+        public async Task<Result<bool>> UrlExistsAsync(string shortCode)
         {
-            // Check if a URL mapping with the given short code exists
-            return await _dbSet.AnyAsync(u => u.ShortCode == shortCode);
+            try {
+                var exists = await _dbSet.AnyAsync(u => u.ShortCode == shortCode);
+                return new Success<bool>(exists);
+            } catch (Exception ex) {
+                _logger.LogError(ex, "Error checking if URL exists");
+                return new Failure<bool>(new Error(ex.Message, ErrorCode.INTERNAL_SERVER_ERROR));
+            }
         }
 
-        public async Task IncrementClickCountAsync(int id)
+        public async Task<Error?> IncrementClickCountAsync(int id)
         {
-            await _context.UrlMappings
-                .Where(u => u.Id == id)
-                .ExecuteUpdateAsync(u =>
-                    u.SetProperty(x => x.ClickCount, x => x.ClickCount + 1));
+            try {
+                await _context.UrlMappings
+                    .Where(u => u.Id == id)
+                    .ExecuteUpdateAsync(u =>
+                        u.SetProperty(x => x.ClickCount, x => x.ClickCount + 1));
+                return null;
+            } catch (Exception ex) {
+                _logger.LogError(ex, "Error incrementing click count");
+                return new Error(ex.Message, ErrorCode.INTERNAL_SERVER_ERROR);
+            }
         }
 
-        public async Task<IEnumerable<UrlMapping>> GetExpiredUrlsAsync()
+        public async Task<Result<IEnumerable<UrlMapping>>> GetExpiredUrlsAsync()
         {
-            return await _context.UrlMappings
+            try {
+                var expiredUrls = await _context.UrlMappings
                 .Where(u => u.IsActive && u.ExpiresAt < DateTime.UtcNow)
                 .ToListAsync();
+                return new Success<IEnumerable<UrlMapping>>(expiredUrls);
+            } catch (Exception ex) {
+                _logger.LogError(ex, "Error fetching expired URLs");
+                return new Failure<IEnumerable<UrlMapping>>(new Error(ex.Message, ErrorCode.INTERNAL_SERVER_ERROR));
+            }
         }
 
     }


### PR DESCRIPTION
Why do services interact with repos, units of work, redis? it handles too much other than the business logic
Wouldn't it be better if the repo handles all the "external connections" 
We would not even need to do any try-catch statements within the service because any exceptional cases will be handled within the corresponding repo which returns a Result to indicate with the operation succeeded with some response value or failed with an Error.
- Maybe the repos can go with the the exceptions business given they are doing most of the work with regard to the external resource